### PR TITLE
Create replay dir if doesn't exists

### DIFF
--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -1,7 +1,7 @@
 use super::RunnableCommand;
 use crate::args::validate_session_description;
 use crate::errors::ReplayError;
-use crate::session::{Session, TEST_ID};
+use crate::session::Session;
 use clap::Args;
 use crossterm::terminal;
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
@@ -137,6 +137,7 @@ impl std::io::Read for RawModeReader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::TEST_ID;
 
     #[test]
     fn record_command_creates_valid_json_sessions() {

--- a/src/session.rs
+++ b/src/session.rs
@@ -2,7 +2,10 @@ use crate::errors::ReplayError;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::env;
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 #[derive(Default, Serialize, Deserialize)]
 pub struct Session {
@@ -13,23 +16,20 @@ pub struct Session {
     commands: Vec<String>,
 }
 
-#[cfg(test)]
-pub const TEST_ID: &str = "test_session";
-
 impl Session {
-    pub fn new(description: Option<String>) -> Self {
+    pub fn new(description: Option<String>) -> Result<Self, ReplayError> {
+        Self::ensure_sessions_dir_exists()?;
         let user = whoami::username();
         let timestamp = Utc::now();
-        Self {
+        Ok(Self {
             commands: Vec::new(),
             id: Self::generate_id(&description, &timestamp, &user),
             description: description,
             timestamp,
             user,
-        }
+        })
     }
 
-    #[cfg(not(test))]
     fn generate_id(
         description: &Option<String>,
         timestamp: &chrono::DateTime<Utc>,
@@ -44,15 +44,6 @@ impl Session {
         hasher.update(timestamp.to_rfc3339().as_bytes());
 
         format!("{:x}", hasher.finalize())
-    }
-
-    #[cfg(test)]
-    fn generate_id(
-        description: &Option<String>,
-        timestamp: &chrono::DateTime<Utc>,
-        user: &str,
-    ) -> String {
-        TEST_ID.to_string()
     }
 
     pub fn add_command(&mut self, cmd_raw: Vec<u8>) {
@@ -83,11 +74,19 @@ impl Session {
         self.commands.iter()
     }
 
-    pub fn get_session_path(id: &str) -> String {
-        format!(
-            "{}/{}.json",
-            env::var("HOME").unwrap_or_else(|_| String::from("/home/user/.replay/sessions")),
-            id
-        )
+    fn get_sessions_dir() -> PathBuf {
+        env::var("HOME")
+            .map(|home| Path::new(&home).join(".replay/sessions"))
+            .unwrap_or_else(|_| Path::new("/home/user/.replay/sessions").to_path_buf())
+    }
+
+    fn ensure_sessions_dir_exists() -> Result<(), ReplayError> {
+        // create the sessions dir if it doesn't already exists
+        std::fs::create_dir_all(Self::get_sessions_dir())?;
+        Ok(())
+    }
+
+    pub fn get_session_path(id: &str) -> PathBuf {
+        Self::get_sessions_dir().join(format!("{}.json", id))
     }
 }


### PR DESCRIPTION
Add a verification func that **ensure the .replay dir exists** and if not **create it.**

The function is basically called on **every** session initialization (in the constructor).