### PR TITLE
Test/13 json command session export

### DIFF
--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -1,12 +1,10 @@
+use std::io::{stdin, stdout};
+
 use super::RunnableCommand;
 use crate::args::validate_session_description;
 use crate::errors::ReplayError;
-use crate::session::Session;
+use crate::pty::run_internal;
 use clap::Args;
-use crossterm::terminal;
-use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
-use std::io::{Read, Write};
-use std::thread;
 
 #[derive(Args, PartialEq, Eq, Debug)]
 pub struct RecordCommand {
@@ -16,86 +14,10 @@ pub struct RecordCommand {
 
 impl RunnableCommand for RecordCommand {
     fn run(&self) -> Result<(), ReplayError> {
-        let mut reader = std::io::stdin();
-        self.run_internal(&mut reader)
+        let mut reader = stdin();
+        let writer = stdout();
+        run_internal(&mut reader, writer, true, self.session_description.clone())
     }
-}
-
-impl RecordCommand {
-    fn run_internal<R: Read>(&self, input_reader: &mut R) -> Result<(), ReplayError> {
-        terminal::enable_raw_mode()?;
-        let pty_system = NativePtySystem::default();
-
-        // Open the PTY with specified size.
-        let pair = pty_system.openpty(PtySize {
-            rows: 24,
-            cols: 80,
-            pixel_width: 0,
-            pixel_height: 0,
-        })?;
-
-        // Set up the command to launch Bash.
-        let cmd = CommandBuilder::new("/bin/bash");
-        let mut child = pair.slave.spawn_command(cmd)?;
-        drop(pair.slave); // No longer used
-
-        // Set up master reader and writer
-        let master_reader = pair.master.try_clone_reader()?;
-        let mut master_writer = pair.master.take_writer()?;
-
-        // Thread to read from the PTY and send data to the main thread.
-        let output_reader = thread::spawn(move || read_from_pty(master_reader));
-
-        // Main thread sends user input to bash stdin
-        let mut buf = [0u8; 1024];
-        let mut cmd_raw: Vec<u8> = Vec::new();
-        let mut session = Session::new(self.session_description.clone()); // TODO : use .take() be self needs to be mut
-
-        loop {
-            if let Some(_) = child.try_wait()? {
-                // replay message
-                break;
-            }
-            match input_reader.read(&mut buf)? {
-                0 => break,
-                n => {
-                    master_writer.write_all(&buf)?;
-                    cmd_raw.extend_from_slice(&buf[..n]);
-                    if cmd_raw.ends_with(b"\r") {
-                        // If the command ends with a newline, we consider it complete.
-                        session.add_command(cmd_raw.clone());
-                        cmd_raw.clear(); // Reset for the next command
-                    }
-                }
-            }
-        }
-        terminal::disable_raw_mode()?;
-        // We don't want the program to panic at any moment since we catch error in the main program and disable_raw mode here
-        output_reader.join().map_err(|paylod| {
-            ReplayError::ThreadPanic(format!("`output_reader` with \n {:?}", paylod))
-        })??;
-
-        session.save_session()?;
-
-        Ok(())
-    }
-}
-
-fn read_from_pty(mut reader: Box<dyn Send + Read>) -> Result<(), ReplayError> {
-    let mut buffer = [0u8; 1024];
-    loop {
-        let n = reader.read(&mut buffer)?;
-        // EOF, if the child entry is closed, we want the thread to exit
-        if n == 0 {
-            break;
-        }
-        #[cfg(not(test))]
-        {
-            std::io::stdout().write_all(&buffer[..n])?;
-            std::io::stdout().flush()?;
-        }
-    }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -104,61 +26,5 @@ impl RecordCommand {
         RecordCommand {
             session_description: desc,
         }
-    }
-}
-#[cfg(test)]
-struct RawModeReader {
-    data: Vec<u8>,
-    pos: usize,
-}
-#[cfg(test)]
-impl RawModeReader {
-    fn new(input: &[u8]) -> Self {
-        Self {
-            data: input.to_vec(),
-            pos: 0,
-        }
-    }
-}
-
-#[cfg(test)]
-impl std::io::Read for RawModeReader {
-    // The following function simulate a raw mode reader reading 1 bytes from the input data at one time
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        if self.pos >= self.data.len() {
-            return Ok(0);
-        }
-        buf[0] = self.data[self.pos];
-        self.pos += 1;
-        Ok(1)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::session::TEST_ID;
-
-    #[test]
-    fn record_command_creates_valid_json_sessions() {
-        let cmd1 = RecordCommand::new(None);
-        let mut reader1 = RawModeReader::new(b"ls\recho test\rexit\r");
-        cmd1.run_internal(&mut reader1).unwrap();
-
-        let file_path = String::from(Session::get_session_path(TEST_ID));
-        let content = std::fs::read_to_string(&file_path).unwrap();
-
-        let session: Session = serde_json::from_str(&content)
-            .expect("The json structure doesn't correspond to the expected session format");
-
-        let mut command_iter = session.iter_commands();
-
-        assert!(command_iter.next().unwrap() == "ls\r");
-
-        assert!(command_iter.next().unwrap() == "echo test\r");
-
-        assert!(command_iter.next().unwrap() == "exit\r");
-
-        assert!(session.description.is_none());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod args;
 pub mod commands;
 pub mod errors;
+pub mod pty;
 pub mod session;
 
 use args::CliParser;

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -1,0 +1,152 @@
+use crate::errors::ReplayError;
+use crate::session::Session;
+use crossterm::terminal;
+use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+use std::io::{Read, Write};
+use std::thread;
+
+pub fn run_internal<R: Read, W: Write + Send + 'static>(
+    mut user_input: R,            // input from user (stdin, pipe…)
+    user_output: W,               // output to user (stdout, file…)
+    record_user_input: bool,      // enable recording of typed commands
+    session_info: Option<String>, // optional session description
+) -> Result<(), ReplayError> {
+    terminal::enable_raw_mode()?;
+    let pty_system = NativePtySystem::default();
+
+    // Open a pseudo-terminal
+    let pty_pair = pty_system.openpty(PtySize {
+        rows: 24,
+        cols: 80,
+        pixel_width: 0,
+        pixel_height: 0,
+    })?;
+
+    // Spawn bash inside PTY
+    let bash_cmd = CommandBuilder::new("/bin/bash");
+    let mut bash_process = pty_pair.slave.spawn_command(bash_cmd)?;
+    drop(pty_pair.slave); // not needed anymore
+
+    // PTY handles for I/O
+    let pty_stdout = pty_pair.master.try_clone_reader()?; // bash → user
+    let mut pty_stdin = pty_pair.master.take_writer()?; // user → bash
+
+    // Thread: forward PTY output to user output
+    let output_thread = thread::spawn(move || read_from_pty(pty_stdout, user_output));
+
+    // Buffers for input and command recording
+    let mut input_buffer = [0u8; 1024];
+    let mut current_command: Vec<u8> = Vec::new();
+
+    // Initialize session recording if enabled
+    let mut session: Option<Session> = if record_user_input {
+        Some(Session::new(session_info)?)
+    } else {
+        None
+    };
+
+    loop {
+        // Exit if bash process ended
+        if let Some(_) = bash_process.try_wait()? {
+            break;
+        }
+
+        match user_input.read(&mut input_buffer)? {
+            0 => break, // no more input
+            n => {
+                // Forward user input to bash (slave)
+                pty_stdin.write_all(&input_buffer[..n])?;
+
+                // Optionally record commands
+                if record_user_input {
+                    current_command.extend_from_slice(&input_buffer[..n]);
+                    if current_command.ends_with(b"\r") {
+                        if let Some(sess) = session.as_mut() {
+                            sess.add_command(current_command.clone());
+                        }
+                        current_command.clear();
+                    }
+                }
+            }
+        }
+    }
+
+    terminal::disable_raw_mode()?;
+
+    // Wait for output thread to finish
+    output_thread.join().map_err(|payload| {
+        ReplayError::ThreadPanic(format!("`output_thread` panicked with \n {:?}", payload))
+    })??;
+
+    // Save session if recording enabled
+    if record_user_input {
+        if let Some(sess) = session.as_mut() {
+            sess.save_session()?;
+        }
+    }
+
+    Ok(())
+}
+
+fn read_from_pty<R: Read + Send, W: Write + Send>(
+    mut pty_output: R,  // PTY → bash output
+    mut user_output: W, // user-visible output
+) -> Result<(), ReplayError> {
+    let mut buffer = [0u8; 1024];
+    loop {
+        let n = pty_output.read(&mut buffer)?;
+        if n == 0 {
+            break;
+        }
+        user_output.write_all(&buffer[..n])?;
+        user_output.flush()?;
+    }
+    Ok(())
+}
+
+pub struct RawModeReader {
+    data: Vec<u8>,
+    pos: usize,
+}
+impl RawModeReader {
+    pub fn new(input: &[u8]) -> Self {
+        Self {
+            data: input.to_vec(),
+            pos: 0,
+        }
+    }
+}
+impl std::io::Read for RawModeReader {
+    // The following function simulate a raw mode reader reading 1 bytes from the input data at one time
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.pos >= self.data.len() {
+            return Ok(0);
+        }
+        buf[0] = self.data[self.pos];
+        self.pos += 1;
+        Ok(1)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::fs;
+    use std::io::sink;
+    #[test]
+    fn record_creates_valid_json_sessions() {
+        let mut reader1 = RawModeReader::new(b"ls\recho test\rexit\r");
+        run_internal(&mut reader1, Box::new(sink()), true, None).unwrap();
+        let file_path = Session::get_session_path("test_session");
+        let content = fs::read_to_string(&file_path).unwrap();
+        let session: Session = serde_json::from_str(&content)
+            .expect("The json structure doesn't correspond to the expected session format");
+
+        let mut command_iter = session.iter_commands();
+        assert_eq!(command_iter.next().unwrap(), "ls\r");
+        assert_eq!(command_iter.next().unwrap(), "echo test\r");
+        assert_eq!(command_iter.next().unwrap(), "exit\r");
+        assert!(session.description.is_none());
+        fs::remove_file(file_path).unwrap();
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -65,7 +65,10 @@ impl Session {
 
     pub fn save_session(&self) -> Result<(), ReplayError> {
         let json = serde_json::to_string_pretty(&self)?;
+        #[cfg(not(test))]
         std::fs::write(Self::get_session_path(&self.id), json)?;
+        #[cfg(test)]
+        std::fs::write(Self::get_session_path("test_session"), json)?;
         Ok(())
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,1 @@
+// Here we will implement the integrations_tests


### PR DESCRIPTION
# Add **unitary** testing support to the json record command.

#### Test spécifications
It tests the internal running pty function in a **record** case to ensure it creates the appropriates internal files 
### Refactoring
We refactored the pty mechanisms in a `pty.rs` file, which contain all of the function relative to pty. They were actually needed by both run/record and the tests.

### Git infos
#### **Dependencies**: 
This branch depends on #18  features so we need to merge if after to the main.
#### **Comparison**:
 We compare it to the branch #18  to see how much it will add to main.
:warning: Change the base branch to main before merging 