### PR TITLE
refactor(pty): `&mut` and `mut` usage behind the pty logic

### DIFF
--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -14,9 +14,9 @@ pub struct RecordCommand {
 
 impl RunnableCommand for RecordCommand {
     fn run(&self) -> Result<(), ReplayError> {
-        let mut reader = stdin();
+        let reader = stdin();
         let writer = stdout();
-        run_internal(&mut reader, writer, true, self.session_description.clone())
+        run_internal(reader, writer, true, self.session_description.clone())
     }
 }
 


### PR DESCRIPTION
- As many other files depends on this signature, we also changed them