### PR TITLE
Fix/handle deletion (char + word) when recording commands

### DIFF
--- a/src/char_buffer.rs
+++ b/src/char_buffer.rs
@@ -8,7 +8,7 @@ impl CharBuffer {
     }
 
     pub fn from_vec(buf: Vec<u8>) -> Self {
-        CharBuffer { buf: buf }
+        CharBuffer { buf }
     }
 
     /// Return the popped character
@@ -27,7 +27,7 @@ impl CharBuffer {
     /// Return the length of the popped word
     pub fn pop_word(&mut self) -> Option<usize> {
         // Remove trailing spaces
-        while Self::peek_char(&self) == Some(&b' ') {
+        while self.peek_char() == Some(&b' ') {
             self.pop_char();
         }
 
@@ -58,6 +58,12 @@ impl CharBuffer {
     }
 }
 
+impl Default for CharBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::CharBuffer;
@@ -68,7 +74,7 @@ mod test {
         assert_eq!(buf.pop_char(), Some(b'c'));
         assert_eq!(buf.pop_char(), Some(b'b'));
         assert_eq!(buf.pop_char(), Some(b'a'));
-        assert_eq!(buf.pop_char(), None); // vide → None
+        assert_eq!(buf.pop_char(), None);
     }
 
     #[test]
@@ -79,7 +85,7 @@ mod test {
         assert_eq!(buf.pop_word(), Some(5)); // `world` is 5 long
         assert_eq!(buf.get_buf(), b"hello "); // With trailing space
         assert_eq!(buf.pop_word(), Some(5)); // `hello` is 5 long
-        assert_eq!(buf.get_buf(), b""); // Now empty
+        assert_eq!(buf.get_buf(), b"");
     }
 
     #[test]
@@ -108,8 +114,8 @@ mod test {
     #[test]
     fn peek_char_returns_last_without_removing() {
         let mut buf = CharBuffer::from_vec(vec![b'x', b'y']);
-        assert_eq!(buf.peek_char(), Some(&b'y')); // peek dernier
-        assert_eq!(buf.get_buf(), b"xy"); // pas consommé
+        assert_eq!(buf.peek_char(), Some(&b'y'));
+        assert_eq!(buf.get_buf(), b"xy");
         buf.pop_char();
         assert_eq!(buf.peek_char(), Some(&b'x'));
     }

--- a/src/char_buffer.rs
+++ b/src/char_buffer.rs
@@ -1,0 +1,117 @@
+pub struct CharBuffer {
+    buf: Vec<u8>,
+}
+
+impl CharBuffer {
+    pub fn new() -> Self {
+        CharBuffer { buf: vec![] }
+    }
+
+    pub fn from_vec(buf: Vec<u8>) -> Self {
+        CharBuffer { buf: buf }
+    }
+
+    /// Return the popped character
+    pub fn pop_char(&mut self) -> Option<u8> {
+        self.buf.pop()
+    }
+
+    pub fn push_char(&mut self, c: u8) {
+        self.buf.push(c);
+    }
+
+    pub fn clear(&mut self) {
+        self.buf.clear();
+    }
+
+    /// Return the length of the popped word
+    pub fn pop_word(&mut self) -> Option<usize> {
+        let buf_len = self.buf.len();
+        for i in (0..buf_len).rev() {
+            if self.buf[i] == b' ' {
+                self.buf.truncate(i);
+                return Some(buf_len - i);
+            }
+        }
+
+        None
+    }
+
+    pub fn peek_char(&self) -> Option<&u8> {
+        self.buf.last()
+    }
+
+    /// Return read-only reference to the buffer
+    pub fn get_buf(&self) -> &[u8] {
+        &self.buf
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::CharBuffer;
+
+    #[test]
+    fn pop_char_returns_last_byte() {
+        let mut buf = CharBuffer::from_vec(vec![b'a', b'b', b'c']);
+        assert_eq!(buf.pop_char(), Some(b'c'));
+        assert_eq!(buf.pop_char(), Some(b'b'));
+        assert_eq!(buf.pop_char(), Some(b'a'));
+        assert_eq!(buf.pop_char(), None); // vide → None
+    }
+
+    #[test]
+    fn pop_word_truncates_at_last_space() {
+        let mut buf = CharBuffer::from_vec(b"hello world test".to_vec());
+        assert_eq!(buf.pop_word(), Some(5)); // supprime " test"
+        assert_eq!(buf.get_buf(), b"hello world");
+        assert_eq!(buf.pop_word(), Some(6)); // supprime " world"
+        assert_eq!(buf.get_buf(), b"hello");
+        assert_eq!(buf.pop_word(), None); // pas d'espace restant
+        assert_eq!(buf.get_buf(), b"hello");
+    }
+
+    #[test]
+    fn pop_word_empty_buffer() {
+        let mut buf = CharBuffer::new();
+        assert_eq!(buf.pop_word(), None);
+    }
+
+    #[test]
+    fn push_char_and_get_buf() {
+        let mut buf = CharBuffer::new();
+        buf.push_char(b'a');
+        buf.push_char(b'b');
+        buf.push_char(b'c');
+        assert_eq!(buf.get_buf(), b"abc");
+    }
+
+    #[test]
+    fn clear_resets_buffer() {
+        let mut buf = CharBuffer::from_vec(b"something".to_vec());
+        buf.clear();
+        assert_eq!(buf.get_buf(), b"");
+        assert_eq!(buf.pop_char(), None);
+    }
+
+    #[test]
+    fn peek_char_returns_last_without_removing() {
+        let mut buf = CharBuffer::from_vec(vec![b'x', b'y']);
+        assert_eq!(buf.peek_char(), Some(&b'y')); // peek dernier
+        assert_eq!(buf.get_buf(), b"xy"); // pas consommé
+        buf.pop_char();
+        assert_eq!(buf.peek_char(), Some(&b'x'));
+    }
+
+    #[test]
+    fn peek_char_empty_buffer() {
+        let buf = CharBuffer::new();
+        assert_eq!(buf.peek_char(), None);
+    }
+
+    #[test]
+    fn from_vec_constructor_works() {
+        let buf = CharBuffer::from_vec(b"abc".to_vec());
+        assert_eq!(buf.get_buf(), b"abc");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 //! - [`errors`] Defines custom error types for the library.
 
 pub mod args;
+pub mod char_buffer;
 pub mod commands;
 pub mod errors;
 pub mod paths;

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -177,7 +177,7 @@ mod test {
     #[test]
     #[serial]
     fn record_creates_valid_json_sessions() {
-        let reader1 = RawModeReader::new(b"ls\recho test\rexit\r");
+        let reader1 = RawModeReader::new(b"ls\recho\x7Fo test\rexit\r");
         run_internal(reader1, Box::new(sink()), true, None).unwrap();
         let file_path = Session::get_session_path("test_session");
         let content = fs::read_to_string(&file_path).unwrap();


### PR DESCRIPTION
Add CharBuffer to handle backspace and word deletion (Ctrl+W) when recording commands

It provides proper handling of:
 - Backspace (\x7F) → removes the last character from the buffer

 - Ctrl+W (\x17) → deletes the last word, including trailing spaces

By centralizing input manipulation into a CharBuffer in [src/char_buffer.rs](src/char_buffer.rs)  the logic becomes more maintainable, easier to extend and to test. 