### PR TITLE
feat: inject Generator trait and mock for unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +342,12 @@ dependencies = [
  "thiserror 1.0.69",
  "winapi",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "futures"
@@ -557,6 +569,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +690,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +762,7 @@ dependencies = [
  "clap",
  "crossterm",
  "dirs",
+ "mockall",
  "portable-pty",
  "rev_lines",
  "serde",
@@ -922,6 +987,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.98"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7442a916bc70e3bf71a5305a899d53301649d2838345fa309420318b5ffafe8"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -699,12 +699,22 @@ dependencies = [
  "crossterm",
  "dirs",
  "portable-pty",
+ "rev_lines",
  "serde",
  "serde_json",
  "serial_test",
  "sha2",
  "thiserror 2.0.15",
  "whoami",
+]
+
+[[package]]
+name = "rev_lines"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed62916ac7a5ccbf13fa5e1d303029ff015600fee841756dfc134a1ac62bf05f"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -734,9 +744,9 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scc"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
 dependencies = [
  "sdd",
 ]
@@ -775,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5.41", features = ["derive"] }
 crossterm = "0.29.0"
 dirs = "6.0.0"
+mockall = "0.13.1"
 portable-pty = "0.9.0"
 rev_lines = "0.3.0"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ clap = { version = "4.5.41", features = ["derive"] }
 crossterm = "0.29.0"
 dirs = "6.0.0"
 portable-pty = "0.9.0"
+rev_lines = "0.3.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
 serial_test = "3.2.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -4,7 +4,7 @@
 //! It will ensure we get the correct args and then return
 //! a correct Structure to run the corresponding commands
 use crate::{
-    commands::{RunnableCommand, record, run},
+    commands::{RunnableCommand, list, record, run},
     errors::ReplayError,
 };
 use clap::{Parser, Subcommand};
@@ -23,6 +23,9 @@ pub enum CliCommand {
 
     /// Record a new session of shell commands
     Record(record::RecordCommand),
+
+    /// List all the sessions recorded
+    List(list::ListCommand),
 }
 
 impl CliCommand {
@@ -30,6 +33,7 @@ impl CliCommand {
         match self {
             CliCommand::Run(cmd) => cmd.run(),
             CliCommand::Record(cmd) => cmd.run(),
+            CliCommand::List(cmd) => cmd.run(),
         }
     }
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -63,7 +63,7 @@ impl ListCommand {
         } else {
             let first_commands_stylized = metadata.first_commands.join(" | ");
             let list_message = format!(
-                "{}, commands:  {} \x1b[0m",
+                "{}, commands: {}",
                 Self::adapt_date_metadata(metadata.timestamp),
                 first_commands_stylized,
             );
@@ -89,21 +89,23 @@ impl ListCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::ShaiGenerator;
     use serial_test::serial;
 
     #[test]
     #[serial]
     fn test_list_format() {
         crate::session::tests::setup();
-        let mut session_1 = Session::new(None).unwrap();
+        let mut session_1 = Session::new(None, ShaiGenerator).unwrap();
         session_1.add_command("ls".into());
         session_1.add_command("echo test".into());
         session_1.save_session().unwrap();
-        let session_2 = Session::new(Some("test session 2".into())).unwrap();
+        let session_2 = Session::new(Some("test session 2".into()), ShaiGenerator).unwrap();
         session_2.save_session().unwrap();
-        let session_3 = Session::new(Some(
-            "session message is too long and should be truncated".into(),
-        ))
+        let session_3 = Session::new(
+            Some("session message is too long and should be truncated".into()),
+            ShaiGenerator,
+        )
         .unwrap();
         session_3.save_session().unwrap();
         let list_output = ListCommand::list().unwrap();

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,0 +1,132 @@
+use super::RunnableCommand;
+use crate::errors::ReplayError;
+use crate::session::MetaData;
+use crate::session::{Session, SessionIndexFile};
+use chrono::Utc;
+use clap::Args;
+use std::io::{BufRead, BufReader};
+
+#[derive(Args, PartialEq, Eq, Debug)]
+pub struct ListCommand {}
+
+impl RunnableCommand for ListCommand {
+    fn run(&self) -> Result<(), ReplayError> {
+        let list_lines = Self::list()?;
+        for line in list_lines {
+            println!("{}", line);
+        }
+        Ok(())
+    }
+}
+
+impl ListCommand {
+    pub fn list() -> Result<Vec<String>, ReplayError> {
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .open(SessionIndexFile::get_path())?;
+        let reader = BufReader::new(file);
+        let lines: Vec<String> = reader.lines().collect::<Result<_, _>>()?;
+
+        let result: Vec<String> = lines
+            .into_iter()
+            .rev()
+            .enumerate()
+            .map(|(i, line)| -> Result<String, ReplayError> {
+                let session_metadata = Session::load_metadata(&line)?;
+                Ok(format!(
+                    "replay@{{{}}} {}",
+                    i,
+                    Self::display_metadata(session_metadata)
+                ))
+            })
+            .collect::<Result<_, _>>()?;
+
+        Ok(result)
+    }
+    fn truncate_description(line: &str, max_len: usize) -> String {
+        let truncated: String = line.chars().take(max_len).collect();
+        if line.chars().count() > max_len {
+            truncated + "..."
+        } else {
+            truncated
+        }
+    }
+
+    fn display_metadata(metadata: MetaData) -> String {
+        if let Some(dess) = metadata.description {
+            let list_message = format!(
+                "{}, message: {}",
+                Self::adapt_date_metadata(metadata.timestamp),
+                dess,
+            );
+            Self::truncate_description(&list_message, 50)
+        } else {
+            let first_commands_stylized = metadata.first_commands.join(" | ");
+            let list_message = format!(
+                "{}, commands:  {} \x1b[0m",
+                Self::adapt_date_metadata(metadata.timestamp),
+                first_commands_stylized,
+            );
+            Self::truncate_description(&list_message, 50)
+        }
+    }
+
+    fn adapt_date_metadata(timestamp: chrono::DateTime<Utc>) -> String {
+        let duration = Utc::now().signed_duration_since(timestamp);
+
+        if duration.num_days() > 0 {
+            format!("{} days ago", duration.num_days())
+        } else if duration.num_hours() > 0 {
+            format!("{} hours ago", duration.num_hours())
+        } else if duration.num_minutes() > 0 {
+            format!("{} minutes ago", duration.num_minutes())
+        } else {
+            format!("{} seconds ago", duration.num_seconds())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn test_list_format() {
+        crate::session::tests::setup();
+        let mut session_1 = Session::new(None).unwrap();
+        session_1.add_command("ls".into());
+        session_1.add_command("echo test".into());
+        session_1.save_session().unwrap();
+        let session_2 = Session::new(Some("test session 2".into())).unwrap();
+        session_2.save_session().unwrap();
+        let session_3 = Session::new(Some(
+            "session message is too long and should be truncated".into(),
+        ))
+        .unwrap();
+        session_3.save_session().unwrap();
+        let list_output = ListCommand::list().unwrap();
+        assert_eq!(
+            format!(
+                "replay@{{0}} {}, message: session message is too lon...",
+                ListCommand::adapt_date_metadata(session_3.timestamp),
+            ),
+            list_output[0]
+        );
+        assert_eq!(
+            format!(
+                "replay@{{1}} {}, message: test session 2",
+                ListCommand::adapt_date_metadata(session_2.timestamp)
+            ),
+            list_output[1]
+        );
+        assert_eq!(
+            format!(
+                "replay@{{2}} {}, commands: ls | echo test",
+                ListCommand::adapt_date_metadata(session_1.timestamp)
+            ),
+            list_output[2]
+        );
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@
 use crate::errors::ReplayError;
 
 // Add commands mod below using pub mod ...
+pub mod list;
 pub mod record;
 pub mod run;
 

--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -4,6 +4,7 @@ use super::RunnableCommand;
 use crate::args::validate_session_description;
 use crate::errors::ReplayError;
 use crate::pty::run_internal;
+use crate::session::ShaiGenerator;
 use clap::Args;
 
 #[derive(Args, PartialEq, Eq, Debug)]
@@ -16,7 +17,13 @@ impl RunnableCommand for RecordCommand {
     fn run(&self) -> Result<(), ReplayError> {
         let reader = stdin();
         let writer = stdout();
-        run_internal(reader, writer, true, self.session_description.clone())
+        run_internal(
+            reader,
+            writer,
+            true,
+            self.session_description.clone(),
+            ShaiGenerator,
+        )
     }
 }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -3,7 +3,7 @@
 use super::RunnableCommand;
 use crate::errors::ReplayError;
 use crate::pty::{RawModeReader, run_internal};
-use crate::session::Session;
+use crate::session::{Session, ShaiGenerator};
 use clap::Args;
 use std::io::stdout;
 
@@ -29,7 +29,7 @@ impl RunnableCommand for RunCommand {
         let commands: String = session.iter_commands().map(|s| s.as_str()).collect();
         let input = RawModeReader::new(commands.as_bytes());
         let output = stdout();
-        run_internal(input, output, false, None)?;
+        run_internal(input, output, false, None, ShaiGenerator)?;
         Ok(())
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,6 +21,9 @@ pub enum ReplayError {
     #[error("Thread panicked: {0}")]
     ThreadPanic(String),
 
+    #[error("Error while reading line in reverse order: {0}")]
+    RevLinesError(#[from] rev_lines::RevLinesError),
+
     #[error("Unknown replay error")]
     Unknown,
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -3,7 +3,7 @@ use crate::paths;
 use chrono::Utc;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fs::File;
-use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 
 #[cfg(not(test))]
@@ -13,6 +13,9 @@ use sha2::{Digest, Sha256};
 pub struct Session {
     pub description: Option<String>,
     pub id: String,
+    #[cfg(test)]
+    pub timestamp: chrono::DateTime<Utc>,
+    #[cfg(not(test))]
     timestamp: chrono::DateTime<Utc>,
     user: String,
     commands: Vec<String>,
@@ -30,12 +33,16 @@ where
     D: Deserializer<'de>,
 {
     let all: Vec<String> = Vec::deserialize(deserializer)?;
-    Ok(all.into_iter().take(2).collect())
+    Ok(all
+        .into_iter()
+        .take(2)
+        .map(|cmd| cmd.replace("\r", ""))
+        .collect())
 }
-struct SessionIndexFile;
+pub struct SessionIndexFile;
 
 impl SessionIndexFile {
-    fn get_path() -> PathBuf {
+    pub fn get_path() -> PathBuf {
         paths::get_replay_dir().join("session_idx")
     }
 
@@ -117,52 +124,6 @@ impl SessionIndexFile {
         file.flush()?;
 
         Ok(session_id)
-    }
-
-    fn truncate_description(line: &str, max_len: usize) -> String {
-        let truncated: String = line.chars().take(max_len).collect();
-        if line.chars().count() > max_len {
-            truncated + "..."
-        } else {
-            truncated
-        }
-    }
-
-    fn display_metadata(metadata: MetaData) -> String {
-        if let Some(dess) = metadata.description {
-            Self::truncate_description(&dess, 50)
-        } else {
-            let list_message = format!(
-                "{} at: {}",
-                metadata.first_commands.join(" | "),
-                metadata.timestamp.format("%Y-%m-%d %H:%M:%S")
-            );
-            Self::truncate_description(&list_message, 50)
-        }
-    }
-
-    pub fn list() -> Result<Vec<String>, ReplayError> {
-        let file = std::fs::OpenOptions::new()
-            .read(true)
-            .open(Self::get_path())?;
-        let reader = BufReader::new(file);
-        let lignes: Vec<String> = reader.lines().collect::<Result<_, _>>()?;
-
-        let result: Vec<String> = lignes
-            .into_iter()
-            .rev()
-            .enumerate()
-            .map(|(i, line)| -> Result<String, ReplayError> {
-                let session_metadata = Session::load_metadata(&line)?;
-                Ok(format!(
-                    "replay@{{{}}} {}",
-                    i,
-                    Self::display_metadata(session_metadata)
-                ))
-            })
-            .collect::<Result<_, _>>()?;
-
-        Ok(result)
     }
 }
 
@@ -249,11 +210,11 @@ impl Session {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use serial_test::serial;
 
-    fn setup() {
+    pub fn setup() {
         let _ = std::fs::remove_file(SessionIndexFile::get_path());
     }
 
@@ -298,35 +259,5 @@ mod tests {
             SessionIndexFile::peek_session_id(),
             Err(ReplayError::SessionError(_))
         ));
-    }
-
-    #[test]
-    #[serial]
-    fn test_list_format() {
-        setup();
-        let mut session_1 = Session::new(None).unwrap();
-        session_1.add_command("ls".into());
-        session_1.add_command("echo test".into());
-        session_1.save_session().unwrap();
-        let session_2 = Session::new(Some("test session 2".into())).unwrap();
-        session_2.save_session().unwrap();
-        let session_3 = Session::new(Some(
-            "test: session message is too long and should be truncated".into(),
-        ))
-        .unwrap();
-        session_3.save_session().unwrap();
-        let list_output = SessionIndexFile::list().unwrap();
-        assert_eq!(
-            "replay@{0} test: session message is too long and should be tr...",
-            list_output[0]
-        );
-        assert_eq!("replay@{1} test session 2", list_output[1]);
-        assert_eq!(
-            format!(
-                "replay@{{2}} ls | echo test at: {}",
-                session_1.timestamp.format("%Y-%m-%d %H:%M:%S")
-            ),
-            list_output[2]
-        );
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 #[cfg(not(test))]
 use sha2::{Digest, Sha256};
 
+
 #[derive(Default, Serialize, Deserialize)]
 pub struct Session {
     pub description: Option<String>,


### PR DESCRIPTION
### Description 
It aims to mock the `generate_id` function using mocking.
In the most idiomatic rust way, it injects a _generator trait_ as dependence in the parameters to be able to mock the comportment in a testing set up.