### PR TITLE
test(clap_parsing): refactor tests for clap parsing

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -35,28 +35,10 @@ impl CliCommand {
 }
 
 pub fn parse_command(args: &[String]) -> Result<CliCommand, ReplayError> {
-    match CliParser::try_parse_from(args) {
-        Ok(parsed_command) => Ok(parsed_command.command),
-        Err(err) => Err(ReplayError::ClapError(err)),
-    }
+    let cli_command = CliParser::try_parse_from(args)?;
+    Ok(cli_command.command)
 }
 
-// TODO: move in RecordCommand
-pub fn validate_session_description(s: &str) -> Result<String, ReplayError> {
-    if s.len() > 30 {
-        return Err(ReplayError::SessionError(String::from(
-            "Session description is too long (max 30 chars)",
-        )));
-    }
-
-    if s.parse::<i32>().is_ok() {
-        return Err(ReplayError::SessionError(String::from(
-            "Session description cannot be an integer",
-        )));
-    }
-
-    Ok(String::from(s))
-}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -68,7 +50,7 @@ mod tests {
             String::from("record"),
             String::from("\"test_valid_record_command\""),
         ];
-        // TODO: remove new command from RecordCommand and add getters to get field as for RunCommand
+
         let expected_command = CliCommand::Record(record::RecordCommand::new(Some(String::from(
             "\"test_valid_record_command\"",
         ))));
@@ -85,19 +67,18 @@ mod tests {
             String::from("--delay"),
             String::from("1"),
         ];
+        let expected_command = CliCommand::Run(run::RunCommand::new(Some(0), true, 1));
+        assert_eq!(expected_command, parse_command(&args).unwrap());
 
-        let parsed_cmd = parse_command(&args).unwrap();
-        if let CliCommand::Run(run_cmd) = parsed_cmd {
-            assert_eq!(run_cmd.get_session_index(), Some(&0));
-            assert!(run_cmd.get_show());
-            assert_eq!(run_cmd.get_delay(), 1);
-        } else {
-            panic!("Expected RunCommand");
-        }
+        // `replay run` is a valid command, it runs the last session by default
+        let args = [String::from("replay"), String::from("run")];
+        let expected_command = CliCommand::Run(run::RunCommand::new(None, false, 0));
+        assert_eq!(expected_command, parse_command(&args).unwrap());
     }
 
     #[test]
     fn test_invalid_run_command() {
+        // Invalid session name
         let args = [
             String::from("replay"),
             String::from("run"),
@@ -106,19 +87,50 @@ mod tests {
             String::from("--delay"),
             String::from("1"),
         ];
+        let res = parse_command(&args);
+        assert!(matches!(res, Err(ReplayError::ClapError(_))));
 
+        // Delay as a char
+        let args = [
+            String::from("replay"),
+            String::from("run"),
+            String::from("replay@{0}"),
+            String::from("--show"),
+            String::from("--delay"),
+            String::from("a"),
+        ];
         let res = parse_command(&args);
         assert!(matches!(res, Err(ReplayError::ClapError(_))));
     }
 
     #[test]
     fn test_invalid_record_command() {
+        // Too short session description
         let args = [
             String::from("replay"),
             String::from("record"),
-            String::from("65"), // An integer cannot be a session name
+            String::from("to short"),
         ];
+        let res = parse_command(&args);
+        assert!(matches!(res, Err(ReplayError::ClapError(_))));
 
+        // Too long session description
+        let args = [
+            String::from("replay"),
+            String::from("record"),
+            String::from(
+                "this session description is way too long and exceeds the maximum length of eighty characters",
+            ),
+        ];
+        let res = parse_command(&args);
+        assert!(matches!(res, Err(ReplayError::ClapError(_))));
+
+        // Invalid session description
+        let args = [
+            String::from("replay"),
+            String::from("record"),
+            String::from("1234567890"),
+        ];
         let res = parse_command(&args);
         assert!(matches!(res, Err(ReplayError::ClapError(_))));
     }

--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -1,14 +1,13 @@
 use std::io::{stdin, stdout};
 
 use super::RunnableCommand;
-use crate::args::validate_session_description;
 use crate::errors::ReplayError;
 use crate::pty::run_internal;
 use clap::Args;
 
 #[derive(Args, PartialEq, Eq, Debug)]
 pub struct RecordCommand {
-    #[arg(value_parser=validate_session_description)]
+    #[arg(value_parser=RecordCommand::validate_session_description)]
     session_description: Option<String>,
 }
 
@@ -20,11 +19,30 @@ impl RunnableCommand for RecordCommand {
     }
 }
 
-#[cfg(test)]
 impl RecordCommand {
+    #[cfg(test)]
     pub fn new(desc: Option<String>) -> Self {
         RecordCommand {
             session_description: desc,
         }
+    }
+
+    fn validate_session_description(s: &str) -> Result<String, String> {
+        if s.len() < 10 {
+            return Err(String::from(
+                "Session description is too short (min 10 chars)",
+            ));
+        }
+        if s.len() > 80 {
+            return Err(String::from(
+                "Session description is too long (max 80 chars)",
+            ));
+        }
+
+        if s.parse::<i32>().is_ok() {
+            return Err(String::from("Session description cannot be an integer"));
+        }
+
+        Ok(String::from(s))
     }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -28,8 +28,8 @@ pub struct RunCommand {
 
 impl RunnableCommand for RunCommand {
     fn run(&self) -> Result<(), ReplayError> {
-        let session: Session = match self.session_index {
-            Some(index) => Session::load_session_by_index(index)?,
+        let session: Session = match &self.session_index {
+            Some(index) => Session::load_session_by_index(*index)?,
             None => Session::load_last_session()?,
         };
         let commands: String = session.iter_commands().map(|s| s.as_str()).collect();
@@ -41,6 +41,15 @@ impl RunnableCommand for RunCommand {
 }
 
 impl RunCommand {
+    #[cfg(test)]
+    pub fn new(session_index: Option<u32>, show: bool, delay: u64) -> Self {
+        Self {
+            session_index,
+            show,
+            delay,
+        }
+    }
+
     fn parse_session_index(s: &str) -> Result<u32, String> {
         s.strip_prefix("replay@{")
             .and_then(|rest| rest.strip_suffix('}'))
@@ -52,23 +61,5 @@ impl RunCommand {
             })?
             .parse::<u32>()
             .map_err(|_| format!("Invalid session index in '{}'", s))
-    }
-
-    #[cfg(test)]
-    /// Get Read-Only Access to the Session Index
-    pub fn get_session_index(&self) -> Option<&u32> {
-        self.session_index.as_ref()
-    }
-
-    #[cfg(test)]
-    /// Get Read-Only Access to show
-    pub fn get_show(&self) -> bool {
-        self.show
-    }
-
-    #[cfg(test)]
-    /// Get Read-Only Access to delay
-    pub fn get_delay(&self) -> u64 {
-        self.delay
     }
 }


### PR DESCRIPTION
- move `validate_session_description` in `RecordCommand`
- use a dedicated new() function for RunCommand only for test
- add tests that test all invalid and valid record command input