### PR TITLE
feat(compressing): add record flag to disable compression

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -51,9 +51,10 @@ mod tests {
             String::from("\"test_valid_record_command\""),
         ];
 
-        let expected_command = CliCommand::Record(record::RecordCommand::new(Some(String::from(
-            "\"test_valid_record_command\"",
-        ))));
+        let expected_command = CliCommand::Record(record::RecordCommand::new(
+            Some(String::from("\"test_valid_record_command\"")),
+            false,
+        ));
         assert_eq!(expected_command, parse_command(&args).unwrap())
     }
 

--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -9,21 +9,31 @@ use clap::Args;
 pub struct RecordCommand {
     #[arg(value_parser=RecordCommand::validate_session_description)]
     session_description: Option<String>,
-}
 
+    /// Disable default file compression
+    #[arg(long)]
+    no_compression: bool,
+}
 impl RunnableCommand for RecordCommand {
     fn run(&self) -> Result<(), ReplayError> {
         let reader = stdin();
         let writer = stdout();
-        run_internal(reader, writer, true, self.session_description.clone())
+        run_internal(
+            reader,
+            writer,
+            true,
+            self.session_description.clone(),
+            self.no_compression,
+        )
     }
 }
 
 impl RecordCommand {
     #[cfg(test)]
-    pub fn new(desc: Option<String>) -> Self {
+    pub fn new(desc: Option<String>, no_compression: bool) -> Self {
         RecordCommand {
             session_description: desc,
+            no_compression,
         }
     }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -35,7 +35,7 @@ impl RunnableCommand for RunCommand {
         let commands: String = session.iter_commands().map(|s| s.as_str()).collect();
         let input = RawModeReader::new(commands.as_bytes());
         let output = stdout();
-        run_internal(input, output, false, None)?;
+        run_internal(input, output, false, None, false)?;
         Ok(())
     }
 }


### PR DESCRIPTION
### Description
Add a clap flag for the record command  `no-compression`.
When used, it disable default file compression.